### PR TITLE
Support attrs version 20 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url="https://github.com/swen128/twitter-text-python",
     packages=find_packages(),
     install_requires=[
-        "attrs~=19.3.0"
+        "attrs>=19.3.0"
     ],
     python_requires='~=3.6',
     classifiers=[


### PR DESCRIPTION
## 修正内容
- `attrs~=19.3.0` -> `attrs>=19.3.0`

## 目的
- `attrs~=19.3.0` だと 19.3.0以上20.0.0未満のバージョンしかサポートされないので、[最新のattrs](https://pypi.org/project/attrs/) に追従できるように `attrs>=19.3.0` に修正したいです

## 背景
- `attrs==21.4.0` の環境で `pip install twitter-text-parser` を実行すると、 `attrs==19.3.0` にダウングレードされる
- `attrs~=19.3.0` の書き方だと `19.3.0` 以上 `20.0.0` 未満になるためだと思われます